### PR TITLE
Fixed the yarn command type

### DIFF
--- a/examples/with-redux-persist/README.md
+++ b/examples/with-redux-persist/README.md
@@ -11,7 +11,7 @@ Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [
 ```bash
 npx create-next-app --example with-redux-persist with-redux-persist-app
 # or
-yarn create next-app --example with-redux-persist with-redux-persist-app
+yarn create-next-app --example with-redux-persist with-redux-persist-app
 ```
 
 ### Download manually


### PR DESCRIPTION
There is typo mistake with create-next-app command ! This pr is directed towards it to solve the typo mistake